### PR TITLE
Switch to proper diff infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,8 +783,8 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da6bc11b07529f16944307272d5bd9b22530bc7d05751717c9d416586cedab49"
 dependencies = [
- "clap",
- "heck",
+ "clap 3.2.25",
+ "heck 0.4.1",
  "indexmap 1.9.3",
  "log",
  "proc-macro2",
@@ -824,11 +872,45 @@ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags 1.3.2",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap 1.9.3",
- "strsim",
+ "strsim 0.10.0",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex 0.7.0",
+ "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -839,6 +921,12 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "clipboard-win"
@@ -920,6 +1008,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "concurrent-queue"
@@ -2227,6 +2321,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2313,6 +2413,7 @@ name = "hx_diff"
 version = "0.1.0"
 dependencies = [
  "assets",
+ "clap 4.5.4",
  "git_cli_wrap",
  "gpui",
  "settings",
@@ -4360,6 +4461,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4374,7 +4481,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -5030,6 +5137,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "util"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,6 +2316,7 @@ dependencies = [
  "git_cli_wrap",
  "gpui",
  "settings",
+ "similar",
  "theme",
  "ui",
 ]
@@ -4173,6 +4174,12 @@ checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "similar"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640"
 
 [[package]]
 name = "simplecss"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 [[package]]
 name = "assets"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#80bc6c8cc800e23ba79723b0c46b731a62203224"
+source = "git+https://github.com/zed-industries/zed#d8e32c3e3cdcb48f64d23b08dc9d821663d09bd2"
 dependencies = [
  "anyhow",
  "gpui",
@@ -552,7 +552,7 @@ checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 [[package]]
 name = "blade-graphics"
 version = "0.3.0"
-source = "git+https://github.com/kvark/blade?rev=43721bf42d298b7cbee2195ee66f73a5f1c7b2fc#43721bf42d298b7cbee2195ee66f73a5f1c7b2fc"
+source = "git+https://github.com/kvark/blade?rev=61cbd6b2c224791d52b150fe535cee665cc91bb2#61cbd6b2c224791d52b150fe535cee665cc91bb2"
 dependencies = [
  "ash",
  "ash-window",
@@ -582,7 +582,7 @@ dependencies = [
 [[package]]
 name = "blade-macros"
 version = "0.2.1"
-source = "git+https://github.com/kvark/blade?rev=43721bf42d298b7cbee2195ee66f73a5f1c7b2fc#43721bf42d298b7cbee2195ee66f73a5f1c7b2fc"
+source = "git+https://github.com/kvark/blade?rev=61cbd6b2c224791d52b150fe535cee665cc91bb2#61cbd6b2c224791d52b150fe535cee665cc91bb2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -853,7 +853,7 @@ dependencies = [
 [[package]]
 name = "clock"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#80bc6c8cc800e23ba79723b0c46b731a62203224"
+source = "git+https://github.com/zed-industries/zed#d8e32c3e3cdcb48f64d23b08dc9d821663d09bd2"
 dependencies = [
  "chrono",
  "smallvec",
@@ -902,7 +902,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#80bc6c8cc800e23ba79723b0c46b731a62203224"
+source = "git+https://github.com/zed-industries/zed#d8e32c3e3cdcb48f64d23b08dc9d821663d09bd2"
 dependencies = [
  "rustc-hash",
 ]
@@ -910,7 +910,7 @@ dependencies = [
 [[package]]
 name = "color"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#80bc6c8cc800e23ba79723b0c46b731a62203224"
+source = "git+https://github.com/zed-industries/zed#d8e32c3e3cdcb48f64d23b08dc9d821663d09bd2"
 dependencies = [
  "palette",
 ]
@@ -1312,7 +1312,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#80bc6c8cc800e23ba79723b0c46b731a62203224"
+source = "git+https://github.com/zed-industries/zed#d8e32c3e3cdcb48f64d23b08dc9d821663d09bd2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1774,7 +1774,7 @@ dependencies = [
 [[package]]
 name = "fs"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#80bc6c8cc800e23ba79723b0c46b731a62203224"
+source = "git+https://github.com/zed-industries/zed#d8e32c3e3cdcb48f64d23b08dc9d821663d09bd2"
 dependencies = [
  "anyhow",
  "async-tar",
@@ -1804,7 +1804,7 @@ dependencies = [
 [[package]]
 name = "fsevent"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#80bc6c8cc800e23ba79723b0c46b731a62203224"
+source = "git+https://github.com/zed-industries/zed#d8e32c3e3cdcb48f64d23b08dc9d821663d09bd2"
 dependencies = [
  "bitflags 2.4.2",
  "fsevent-sys 3.1.0",
@@ -2103,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#80bc6c8cc800e23ba79723b0c46b731a62203224"
+source = "git+https://github.com/zed-industries/zed#d8e32c3e3cdcb48f64d23b08dc9d821663d09bd2"
 dependencies = [
  "anyhow",
  "as-raw-xcb-connection",
@@ -2183,7 +2183,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#80bc6c8cc800e23ba79723b0c46b731a62203224"
+source = "git+https://github.com/zed-industries/zed#d8e32c3e3cdcb48f64d23b08dc9d821663d09bd2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2317,6 +2317,7 @@ dependencies = [
  "gpui",
  "settings",
  "theme",
+ "ui",
 ]
 
 [[package]]
@@ -2767,7 +2768,7 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#80bc6c8cc800e23ba79723b0c46b731a62203224"
+source = "git+https://github.com/zed-industries/zed#d8e32c3e3cdcb48f64d23b08dc9d821663d09bd2"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -2835,6 +2836,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "menu"
+version = "0.1.0"
+source = "git+https://github.com/zed-industries/zed#d8e32c3e3cdcb48f64d23b08dc9d821663d09bd2"
+dependencies = [
+ "gpui",
+ "serde",
 ]
 
 [[package]]
@@ -3697,7 +3707,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#80bc6c8cc800e23ba79723b0c46b731a62203224"
+source = "git+https://github.com/zed-industries/zed#d8e32c3e3cdcb48f64d23b08dc9d821663d09bd2"
 dependencies = [
  "derive_refineable",
 ]
@@ -3747,7 +3757,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 [[package]]
 name = "release_channel"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#80bc6c8cc800e23ba79723b0c46b731a62203224"
+source = "git+https://github.com/zed-industries/zed#d8e32c3e3cdcb48f64d23b08dc9d821663d09bd2"
 dependencies = [
  "gpui",
  "once_cell",
@@ -3781,7 +3791,7 @@ dependencies = [
 [[package]]
 name = "rope"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#80bc6c8cc800e23ba79723b0c46b731a62203224"
+source = "git+https://github.com/zed-industries/zed#d8e32c3e3cdcb48f64d23b08dc9d821663d09bd2"
 dependencies = [
  "arrayvec 0.7.4",
  "bromberg_sl2",
@@ -3882,6 +3892,12 @@ dependencies = [
  "linux-raw-sys 0.4.13",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "rustybuzz"
@@ -4094,7 +4110,7 @@ dependencies = [
 [[package]]
 name = "settings"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#80bc6c8cc800e23ba79723b0c46b731a62203224"
+source = "git+https://github.com/zed-industries/zed#d8e32c3e3cdcb48f64d23b08dc9d821663d09bd2"
 dependencies = [
  "anyhow",
  "collections",
@@ -4337,6 +4353,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.53",
+]
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4345,7 +4383,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#80bc6c8cc800e23ba79723b0c46b731a62203224"
+source = "git+https://github.com/zed-industries/zed#d8e32c3e3cdcb48f64d23b08dc9d821663d09bd2"
 dependencies = [
  "arrayvec 0.7.4",
  "log",
@@ -4556,7 +4594,7 @@ dependencies = [
 [[package]]
 name = "text"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#80bc6c8cc800e23ba79723b0c46b731a62203224"
+source = "git+https://github.com/zed-industries/zed#d8e32c3e3cdcb48f64d23b08dc9d821663d09bd2"
 dependencies = [
  "anyhow",
  "clock",
@@ -4581,7 +4619,7 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 [[package]]
 name = "theme"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#80bc6c8cc800e23ba79723b0c46b731a62203224"
+source = "git+https://github.com/zed-industries/zed#d8e32c3e3cdcb48f64d23b08dc9d821663d09bd2"
 dependencies = [
  "anyhow",
  "collections",
@@ -4838,6 +4876,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ui"
+version = "0.1.0"
+source = "git+https://github.com/zed-industries/zed#d8e32c3e3cdcb48f64d23b08dc9d821663d09bd2"
+dependencies = [
+ "chrono",
+ "gpui",
+ "menu",
+ "settings",
+ "smallvec",
+ "strum",
+ "theme",
+]
+
+[[package]]
 name = "unicase"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4975,7 +5027,7 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#80bc6c8cc800e23ba79723b0c46b731a62203224"
+source = "git+https://github.com/zed-industries/zed#d8e32c3e3cdcb48f64d23b08dc9d821663d09bd2"
 dependencies = [
  "anyhow",
  "async-fs 1.6.0",

--- a/TODO.md
+++ b/TODO.md
@@ -1,2 +1,3 @@
+1. Global entries list
 2. Staged and Unstaged
 3. Tree structure in file list

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,7 @@
 1. Global entries list
 2. Staged and Unstaged
 3. Tree structure in file list
+
+# Git command plan
+
+git cat-file --filters --path=<path> <sha1>

--- a/git_cli_wrap/src/lib.rs
+++ b/git_cli_wrap/src/lib.rs
@@ -12,6 +12,38 @@ impl Sha1Hash {
 		hash.copy_from_slice(&bytes);
 		Sha1Hash(hash)
 	}
+
+	pub fn is_zero(&self) -> bool {
+		self.0.iter().all(|&b| b == '0' as u8)
+	}
+}
+
+#[derive(Debug)]
+pub enum FileStatus {
+	Added,
+	Copy,
+	Deleted,
+	Modified,
+	Renamed,
+	TypeChange,
+	Unmerged,
+}
+
+impl FileStatus {
+	pub fn from_str(status: &str) -> FileStatus {
+		assert!(status.len() == 1);
+		let status_char = status.chars().next().unwrap();
+		match status_char {
+			'A' => FileStatus::Added,
+			'C' => FileStatus::Copy,
+			'D' => FileStatus::Deleted,
+			'M' => FileStatus::Modified,
+			'R' => FileStatus::Renamed,
+			'T' => FileStatus::TypeChange,
+			'U' => FileStatus::Unmerged,
+			_ => panic!("Unknown status: {}", status_char),
+		}
+	}
 }
 
 #[derive(Debug)]
@@ -39,11 +71,39 @@ pub struct ShowEntry {
 	pub left_sha1: Sha1Hash,
 	pub right_sha1: Sha1Hash,
 	pub path: std::path::PathBuf,
+	pub status: FileStatus,
+}
+
+impl ShowEntry {
+	pub fn from_line(line: &str) -> Self {
+		assert!(line.starts_with(':'));
+		let mut iter = line[1..].split_whitespace();
+		let _mode1 = iter.next().unwrap();
+		let _mode2 = iter.next().unwrap();
+		let left_sha1 = iter.next().unwrap();
+		let right_sha1 = iter.next().unwrap();
+		let status = iter.next().unwrap();
+		let path = iter.next().unwrap();
+
+		ShowEntry {
+			left_status: EntryStatus::None,
+			right_status: EntryStatus::None,
+			left_sha1: Sha1Hash::from_bytes(left_sha1.as_bytes()),
+			right_sha1: Sha1Hash::from_bytes(right_sha1.as_bytes()),
+			status: FileStatus::from_str(status),
+			path: std::path::Path::new(path).canonicalize().unwrap(),
+		}
+	}
 }
 
 #[derive(Debug)]
 pub struct GitShow {
 	pub description: String,
+	pub entries: Vec<ShowEntry>,
+}
+
+#[derive(Debug)]
+pub struct GitDiff {
 	pub entries: Vec<ShowEntry>,
 }
 
@@ -143,17 +203,13 @@ fn parse_status(status: &str) -> Result<GitStatus, GitError> {
 	})
 }
 
-pub fn get_diff(path: &std::path::Path, is_staged: bool) -> Result<String, GitError> {
-	let mut cmd = Command::new("git");
-	cmd.arg("diff").arg("-p");
-
-	if is_staged {
-		cmd.arg("--staged");
-	}
-
-	let cmd = cmd.arg("--").arg(path);
-
-	let output = cmd.output().expect("failed to execute process");
+pub fn get_diff() -> Result<GitDiff, GitError> {
+	let output = Command::new("git")
+		.arg("diff")
+		.arg("--abbrev=40")
+		.arg("--raw")
+		.output()
+		.expect("failed to execute process");
 
 	if !output.status.success() {
 		println!("Error: Failed to run git diff");
@@ -167,11 +223,12 @@ pub fn get_diff(path: &std::path::Path, is_staged: bool) -> Result<String, GitEr
 
 	let output_string = String::from_utf8(output.stdout).expect("Invalid utf-8");
 
-	if let Some(body_start) = output_string.find("@@ ") {
-		Ok(output_string[body_start..].to_string())
-	} else {
-		Err(GitError {})
-	}
+	let entries = output_string
+		.lines()
+		.map(ShowEntry::from_line)
+		.collect::<Vec<_>>();
+
+	Ok(GitDiff { entries })
 }
 
 pub fn get_file_contents(path: &std::path::Path, sha1: &Sha1Hash) -> Result<String, GitError> {
@@ -229,21 +286,7 @@ pub fn show(commit: &str) -> Result<GitShow, GitError> {
 		if !line.starts_with(':') {
 			description.push_str(line);
 		} else {
-			let mut iter = line[1..].split_whitespace();
-			let _mode1 = iter.next().unwrap();
-			let _mode2 = iter.next().unwrap();
-			let left_sha1 = iter.next().unwrap();
-			let right_sha1 = iter.next().unwrap();
-			let _mode = iter.next().unwrap();
-			let path = iter.next().unwrap();
-
-			entries.push(ShowEntry {
-				left_status: EntryStatus::None,
-				right_status: EntryStatus::None,
-				left_sha1: Sha1Hash::from_bytes(left_sha1.as_bytes()),
-				right_sha1: Sha1Hash::from_bytes(right_sha1.as_bytes()),
-				path: std::path::Path::new(path).canonicalize().unwrap(),
-			});
+			entries.push(ShowEntry::from_line(line));
 		}
 	}
 

--- a/git_cli_wrap/src/lib.rs
+++ b/git_cli_wrap/src/lib.rs
@@ -95,7 +95,7 @@ fn parse_status(status: &str) -> Result<GitStatus, GitError> {
 			let staged_status = EntryStatus::from_u8(&file_status.as_bytes()[0]);
 			let unstaged_status = EntryStatus::from_u8(&file_status.as_bytes()[1]);
 
-			iter.nth(2); // Skip: file mode for HEAD, index, worktree
+			iter.nth(3); // Skip: file mode for HEAD, index, worktree
 			 // TODO: Handle rename confidence parameter
 
 			let head_sha1 = iter.next().unwrap().to_owned();

--- a/git_cli_wrap/src/lib.rs
+++ b/git_cli_wrap/src/lib.rs
@@ -153,13 +153,24 @@ pub fn get_diff(path: &std::path::Path, is_staged: bool) -> Result<String, GitEr
 	}
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
+pub fn get_file_contents(path: &std::path::Path, sha1: &Sha1Hash) -> Result<String, GitError> {
+	let output = Command::new("git")
+		.arg("cat-file")
+		.arg("--filters")
+		.arg(format!("--path={}", path.display()))
+		.arg(std::str::from_utf8(&sha1.0).unwrap())
+		.output()
+		.expect("failed to execute process");
 
-//     #[test]
-//     fn it_works() {
-//         let result = add(2, 2);
-//         assert_eq!(result, 4);
-//     }
-// }
+	if !output.status.success() {
+		println!("Error: Failed to run git cat-file");
+		println!("---");
+		println!(
+			"{}",
+			String::from_utf8(output.stderr).expect("Invalid utf-8")
+		);
+		return Err(GitError {});
+	}
+
+	Ok(String::from_utf8(output.stdout).expect("Invalid utf-8"))
+}

--- a/hx_diff/Cargo.toml
+++ b/hx_diff/Cargo.toml
@@ -10,4 +10,5 @@ gpui = { git = "https://github.com/zed-industries/zed" }
 theme = { git = "https://github.com/zed-industries/zed" }
 settings = { git = "https://github.com/zed-industries/zed" }
 assets = { git = "https://github.com/zed-industries/zed" }
+ui = { git = "https://github.com/zed-industries/zed" }
 git_cli_wrap = { path = "../git_cli_wrap" }

--- a/hx_diff/Cargo.toml
+++ b/hx_diff/Cargo.toml
@@ -12,3 +12,4 @@ settings = { git = "https://github.com/zed-industries/zed" }
 assets = { git = "https://github.com/zed-industries/zed" }
 ui = { git = "https://github.com/zed-industries/zed" }
 git_cli_wrap = { path = "../git_cli_wrap" }
+similar = "2.5.0"

--- a/hx_diff/Cargo.toml
+++ b/hx_diff/Cargo.toml
@@ -6,10 +6,13 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+git_cli_wrap = { path = "../git_cli_wrap" }
+
+clap = { version = "4.5.4", features = ["derive"] }
+similar = "2.5.0"
+
 gpui = { git = "https://github.com/zed-industries/zed" }
 theme = { git = "https://github.com/zed-industries/zed" }
 settings = { git = "https://github.com/zed-industries/zed" }
 assets = { git = "https://github.com/zed-industries/zed" }
 ui = { git = "https://github.com/zed-industries/zed" }
-git_cli_wrap = { path = "../git_cli_wrap" }
-similar = "2.5.0"

--- a/hx_diff/src/main.rs
+++ b/hx_diff/src/main.rs
@@ -1,5 +1,6 @@
 mod common;
 mod views;
+mod workspace;
 
 use crate::common::{setup_window, HEIGHT, WIDTH};
 use assets::Assets;
@@ -34,6 +35,8 @@ fn cycle_theme(cx: &mut AppContext) {
 	cx.refresh()
 }
 
+// Another..
+//
 fn main() {
 	App::new().run(|cx: &mut AppContext| {
 		let mut store = SettingsStore::default();

--- a/hx_diff/src/main.rs
+++ b/hx_diff/src/main.rs
@@ -43,6 +43,9 @@ struct Args {
 	mode: Option<String>,
 
 	arg: Option<String>,
+
+	#[arg(long = "merge-base")]
+	merge_base: Option<String>,
 }
 
 fn translate_args(args: &Args) -> WorkspaceArgs {
@@ -54,14 +57,17 @@ fn translate_args(args: &Args) -> WorkspaceArgs {
 				.to_string(),
 		),
 		None | Some("status") => WorkspaceAction::GitStatus,
+		Some("diff") => WorkspaceAction::GitDiff,
 		_ => panic!("Invalid mode"),
 	};
 
+	// TODO - flags (merge-base)   Pair<String, String>.  Pair<Enum, String>?
 	WorkspaceArgs { action, path: None }
 }
 
 fn main() {
 	let args = Args::parse();
+	println!("Args = {:?}", args);
 
 	App::new().run(move |cx: &mut AppContext| {
 		let mut store = SettingsStore::default();

--- a/hx_diff/src/main.rs
+++ b/hx_diff/src/main.rs
@@ -3,11 +3,12 @@ mod views;
 mod workspace;
 
 use crate::common::{setup_window, HEIGHT, WIDTH};
+use crate::workspace::*;
 use assets::Assets;
+use clap::Parser;
 use git_cli_wrap;
 use gpui::*;
 use settings::{default_settings, Settings, SettingsStore};
-use std::env;
 use views::*;
 
 actions!(
@@ -35,10 +36,34 @@ fn cycle_theme(cx: &mut AppContext) {
 	cx.refresh()
 }
 
-// Another..
-//
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+	/// Sub-commmand to run
+	mode: Option<String>,
+
+	arg: Option<String>,
+}
+
+fn translate_args(args: &Args) -> WorkspaceArgs {
+	let action = match args.mode.as_deref() {
+		Some("show") => WorkspaceAction::GitShow(
+			args.arg
+				.as_ref()
+				.expect("Missing commit argument for 'show'")
+				.to_string(),
+		),
+		None | Some("status") => WorkspaceAction::GitStatus,
+		_ => panic!("Invalid mode"),
+	};
+
+	WorkspaceArgs { action, path: None }
+}
+
 fn main() {
-	App::new().run(|cx: &mut AppContext| {
+	let args = Args::parse();
+
+	App::new().run(move |cx: &mut AppContext| {
 		let mut store = SettingsStore::default();
 		store
 			.set_default_settings(default_settings().as_ref(), cx)
@@ -49,18 +74,7 @@ fn main() {
 		theme::init(theme::LoadThemes::All(Box::new(Assets)), cx);
 
 		let theme_registry = theme::ThemeRegistry::global(cx);
-
-		let args: Vec<String> = env::args().collect();
-		let theme_name = if args.len() > 1 {
-			if args[1].chars().all(|c| c.is_ascii_digit()) {
-				let all_themes = theme_registry.list_names(true);
-				all_themes[args[1].parse::<usize>().expect("Invalid theme index")].to_string()
-			} else {
-				args[1].to_string()
-			}
-		} else {
-			"One Dark".to_string()
-		};
+		let theme_name = "One Dark";
 
 		let mut theme_settings = theme::ThemeSettings::get_global(cx).clone();
 		theme_settings.active_theme = theme_registry.get(&theme_name).unwrap();
@@ -102,7 +116,9 @@ fn main() {
 			},
 		]);
 
-		cx.open_window(options, |cx| cx.new_view(HxDiff::new));
+		let workspace = cx.new_model(|_cx| Workspace::from_args(translate_args(&args)));
+
+		cx.open_window(options, |cx| HxDiff::new(workspace, cx));
 		cx.activate(true);
 	});
 }

--- a/hx_diff/src/views/diff_pane.rs
+++ b/hx_diff/src/views/diff_pane.rs
@@ -40,11 +40,14 @@ impl DiffPane {
 
 	pub fn get_file_contents(file_entry: &FileEntry, file_source: &FileSource) -> String {
 		match file_source {
+			FileSource::Empty => String::new(),
 			FileSource::Working => {
 				println!("Getting contents: Working");
 				std::fs::read_to_string(&file_entry.path).expect("Could not read file.")
 			}
-			FileSource::Index(ref sha1) | FileSource::Head(ref sha1) => {
+			FileSource::Commit(ref sha1)
+			| FileSource::Index(ref sha1)
+			| FileSource::Head(ref sha1) => {
 				println!("Getting contents: Index");
 				git::get_file_contents(&file_entry.path, sha1).expect("Failed to get Index content")
 			}

--- a/hx_diff/src/views/diff_pane.rs
+++ b/hx_diff/src/views/diff_pane.rs
@@ -64,7 +64,8 @@ impl DiffPane {
 		_cx: &mut ViewContext<Self>,
 	) {
 		self.diff_text = SharedString::from(
-			git_cli_wrap::get_diff(&filename, is_staged).expect("Could not read file."),
+			git_cli_wrap::get_diff(&filename, is_staged)
+				.expect(&format!("Could not read file: {}.", filename.display())),
 		);
 
 		self.diff_lines = process_diff(&self.diff_text);

--- a/hx_diff/src/views/file_list.rs
+++ b/hx_diff/src/views/file_list.rs
@@ -4,13 +4,13 @@ use hx_diff::{DraggedPanel, PanelPosition};
 use std::path::PathBuf;
 use theme::ActiveTheme;
 
-use self::workspace::{Entry, EntryKind, ProjectEntryId, Workspace};
+use self::workspace::{EntryKind, ProjectEntryId, Workspace};
 
 const RESIZE_HANDLE_SIZE: Pixels = Pixels(6.);
 
 #[derive(Debug)]
 pub enum FileListEvent {
-	OpenedEntry { filename: PathBuf, is_staged: bool }, // TODO: flush out to be a full specification of the file/diff
+	OpenedEntry { entry_id: ProjectEntryId },
 }
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
@@ -163,10 +163,7 @@ impl FileList {
 				.id(id.to_usize())
 				.on_click(cx.listener(move |_this, _event: &gpui::ClickEvent, cx| {
 					if item_type == ListItemType::File {
-						cx.emit(FileListEvent::OpenedEntry {
-							filename: path.clone(),
-							is_staged: false,
-						});
+						cx.emit(FileListEvent::OpenedEntry { entry_id: id });
 					}
 				}))
 				.child(

--- a/hx_diff/src/views/file_list.rs
+++ b/hx_diff/src/views/file_list.rs
@@ -58,9 +58,11 @@ impl FileList {
 					EntryKind::Category(workspace::CategoryKind::Working) => {
 						"UNSTAGED - Changes not staged for commit".into()
 					}
-					EntryKind::Category(workspace::CategoryKind::Commit) => "TODO".into(),
+					EntryKind::Category(workspace::CategoryKind::Commit) => {
+						"Commit Details Here".into()
+					}
 					EntryKind::Directory(_) => entry.path.to_string_lossy().into_owned().into(),
-					EntryKind::File(ref name) => entry
+					EntryKind::File(ref _name) => entry
 						.path
 						.file_name()
 						.unwrap()

--- a/hx_diff/src/views/file_list.rs
+++ b/hx_diff/src/views/file_list.rs
@@ -19,6 +19,8 @@ enum ListItemType {
 	File,
 }
 
+// Test - TODO, delete me
+
 #[derive(Debug)]
 struct ListItem {
 	item_type: ListItemType,

--- a/hx_diff/src/views/hx_diff.rs
+++ b/hx_diff/src/views/hx_diff.rs
@@ -18,14 +18,16 @@ pub struct HxDiff {
 	weak_self: WeakView<Self>,
 	file_pane: View<FileList>,
 	diff_pane: View<DiffPane>,
-
-	workspace: Option<Workspace>,
+	workspace: Model<Workspace>,
 }
 
 impl HxDiff {
 	pub fn new(cx: &mut ViewContext<Self>) -> HxDiff {
 		let weak_handle = cx.view().downgrade();
-		let file_pane = FileList::new(weak_handle.clone(), cx);
+
+		let workspace = cx.new_model(|_cx| Workspace::for_git_status());
+
+		let file_pane = FileList::new(weak_handle.clone(), workspace.clone(), cx);
 		let diff_pane = DiffPane::new(weak_handle.clone(), cx);
 
 		cx.subscribe(&file_pane, {
@@ -44,7 +46,7 @@ impl HxDiff {
 			weak_self: weak_handle,
 			file_pane,
 			diff_pane,
-			workspace: None,
+			workspace: workspace.clone(),
 		}
 	}
 

--- a/hx_diff/src/views/hx_diff.rs
+++ b/hx_diff/src/views/hx_diff.rs
@@ -28,15 +28,12 @@ impl HxDiff {
 		let workspace = cx.new_model(|_cx| Workspace::for_git_status());
 
 		let file_pane = FileList::new(weak_handle.clone(), workspace.clone(), cx);
-		let diff_pane = DiffPane::new(weak_handle.clone(), cx);
+		let diff_pane = DiffPane::new(weak_handle.clone(), workspace.clone(), cx);
 
 		cx.subscribe(&file_pane, {
 			move |hx_diff, _, event, cx| match event {
-				&FileListEvent::OpenedEntry {
-					ref filename,
-					is_staged,
-				} => {
-					hx_diff.open_file(filename, is_staged, cx);
+				&FileListEvent::OpenedEntry { entry_id } => {
+					hx_diff.open_file(entry_id, cx);
 				}
 			}
 		})
@@ -54,14 +51,9 @@ impl HxDiff {
 		self.weak_self.clone()
 	}
 
-	fn open_file(
-		&mut self,
-		filename: &std::path::Path,
-		is_staged: bool,
-		cx: &mut ViewContext<Self>,
-	) {
+	fn open_file(&mut self, id: ProjectEntryId, cx: &mut ViewContext<Self>) {
 		self.diff_pane.update(cx, |diff_pane, cx| {
-			diff_pane.open_diff(filename, is_staged, cx);
+			diff_pane.open_diff(id, cx);
 		});
 	}
 }

--- a/hx_diff/src/views/hx_diff.rs
+++ b/hx_diff/src/views/hx_diff.rs
@@ -3,6 +3,8 @@ use gpui::prelude::*;
 use gpui::*;
 use theme::ActiveTheme;
 
+use crate::workspace::*;
+
 #[derive(Clone)]
 pub enum PanelPosition {
 	Left,
@@ -16,6 +18,8 @@ pub struct HxDiff {
 	weak_self: WeakView<Self>,
 	file_pane: View<FileList>,
 	diff_pane: View<DiffPane>,
+
+	workspace: Option<Workspace>,
 }
 
 impl HxDiff {
@@ -40,6 +44,7 @@ impl HxDiff {
 			weak_self: weak_handle,
 			file_pane,
 			diff_pane,
+			workspace: None,
 		}
 	}
 

--- a/hx_diff/src/workspace.rs
+++ b/hx_diff/src/workspace.rs
@@ -1,0 +1,149 @@
+// Functions for managing the main state of the application
+// Including all scanned files, app query parameters, etc.
+use core::sync::atomic::AtomicUsize;
+use core::sync::atomic::Ordering::SeqCst;
+use git_cli_wrap as git;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+#[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ProjectEntryId(usize);
+
+impl ProjectEntryId {
+	pub const MAX: Self = Self(usize::MAX);
+
+	pub fn new(counter: &AtomicUsize) -> Self {
+		Self(counter.fetch_add(1, SeqCst))
+	}
+}
+
+// pub struct Sha1Hash([u8; 40]);
+// pub struct Sha1Hash(String);
+
+pub enum FileSource {
+	// TODO, name
+	Working,
+	Index(git::Sha1Hash),
+	Head(git::Sha1Hash),
+	Commit(git::Sha1Hash),
+}
+
+pub enum CategoryKind {
+	Staged,
+	Working,
+	Commit,
+}
+
+pub struct FileEntry {
+	path: PathBuf,
+	left_source: FileSource,
+	right_source: FileSource,
+}
+
+pub enum EntryKind {
+	Category(CategoryKind),
+	File(FileEntry),
+	Directory(PathBuf),
+}
+
+// File details:
+//  LeftState (Staged, )
+//
+// File State: HEAD, Commit, Index (staging), Working Directory
+
+pub struct Entry {
+	id: ProjectEntryId,
+	kind: EntryKind,
+	path: PathBuf,
+	// status: String,
+}
+
+pub struct Workspace {
+	// entries: HashMap<ProjectEntryId, Entry>,
+	entries: Vec<Entry>,
+}
+
+impl Workspace {
+	fn for_git_status() -> Self {
+		let git_status = git::get_status().expect("Failed to get git status");
+
+		// let mut entries = HashMap::new();
+		let counter = AtomicUsize::new(0);
+		let mut entries = Vec::new();
+
+		let mut process_items = |get_status: fn(&git::Entry) -> git::EntryStatus,
+		                         is_staged: bool,
+		                         category_name: &'static str| {
+			let mut has_items = false;
+			let mut last_dir = None;
+
+			for entry in git_status
+				.entries
+				.iter()
+				.filter(|e| get_status(e) != git::EntryStatus::None)
+			{
+				let path = &entry.path;
+
+				if !has_items {
+					entries.push(Entry {
+						id: ProjectEntryId::new(&counter),
+						kind: if is_staged {
+							EntryKind::Category(CategoryKind::Staged)
+						} else {
+							EntryKind::Category(CategoryKind::Working)
+						},
+						path: path.clone().into(),
+					});
+					has_items = true;
+				}
+				let parent_dir = path.parent().expect(&format!(
+					"Failed to get parent directory for '{}'",
+					entry.path.display()
+				));
+
+				if Some(parent_dir) != last_dir {
+					last_dir = Some(parent_dir);
+					entries.push(Entry {
+						id: ProjectEntryId::new(&counter),
+						kind: EntryKind::Directory(parent_dir.into()),
+						path: parent_dir.to_owned(),
+					});
+				}
+
+				// let status = get_status(entry).to_string();
+				let file_entry = FileEntry {
+					path: path.clone(),
+					left_source: if is_staged {
+						FileSource::Head(entry.head_sha1)
+					} else {
+						FileSource::Index(entry.index_sha1)
+					},
+					right_source: if is_staged {
+						FileSource::Index(entry.index_sha1)
+					} else {
+						FileSource::Working
+					},
+				};
+
+				entries.push(Entry {
+					id: ProjectEntryId::new(&counter),
+					kind: EntryKind::File(file_entry),
+					path: path.clone(),
+				});
+			}
+		};
+
+		process_items(
+			|e| e.staged_status,
+			/*is_staged=*/ true,
+			"STAGED - Changes to be committed",
+		);
+		process_items(
+			|e| e.unstaged_status,
+			/*is_staged=*/ false,
+			"WORKING - Changes not staged for commit",
+		);
+
+		return Workspace { entries };
+	}
+}

--- a/hx_diff/src/workspace.rs
+++ b/hx_diff/src/workspace.rs
@@ -3,7 +3,6 @@
 use core::sync::atomic::AtomicUsize;
 use core::sync::atomic::Ordering::SeqCst;
 use git_cli_wrap as git;
-use std::collections::HashMap;
 use std::path::PathBuf;
 
 #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -14,6 +13,14 @@ impl ProjectEntryId {
 
 	pub fn new(counter: &AtomicUsize) -> Self {
 		Self(counter.fetch_add(1, SeqCst))
+	}
+
+	pub fn to_proto(&self) -> u64 {
+		self.0 as u64
+	}
+
+	pub fn to_usize(&self) -> usize {
+		self.0
 	}
 }
 
@@ -52,19 +59,20 @@ pub enum EntryKind {
 // File State: HEAD, Commit, Index (staging), Working Directory
 
 pub struct Entry {
-	id: ProjectEntryId,
-	kind: EntryKind,
-	path: PathBuf,
+	pub id: ProjectEntryId,
+	pub kind: EntryKind,
+	pub path: PathBuf,
 	// status: String,
 }
 
 pub struct Workspace {
 	// entries: HashMap<ProjectEntryId, Entry>,
-	entries: Vec<Entry>,
+	pub entries: Vec<Entry>,
 }
 
 impl Workspace {
-	fn for_git_status() -> Self {
+	pub fn for_git_status() -> Self {
+		println!("Workspace::for_git_status()");
 		let git_status = git::get_status().expect("Failed to get git status");
 
 		// let mut entries = HashMap::new();

--- a/hx_diff/src/workspace.rs
+++ b/hx_diff/src/workspace.rs
@@ -84,7 +84,7 @@ impl Workspace {
 		let counter = AtomicUsize::new(0);
 		let mut entries = Vec::new();
 
-		let mut process_items = |get_status: fn(&git::Entry) -> git::EntryStatus,
+		let mut process_items = |get_status: fn(&git::StatusEntry) -> git::EntryStatus,
 		                         is_staged: bool,
 		                         category_name: &'static str| {
 			let mut has_items = false;

--- a/hx_diff/src/workspace.rs
+++ b/hx_diff/src/workspace.rs
@@ -42,9 +42,9 @@ pub enum CategoryKind {
 }
 
 pub struct FileEntry {
-	path: PathBuf,
-	left_source: FileSource,
-	right_source: FileSource,
+	pub path: PathBuf,
+	pub left_source: FileSource,
+	pub right_source: FileSource,
 }
 
 pub enum EntryKind {
@@ -71,6 +71,11 @@ pub struct Workspace {
 }
 
 impl Workspace {
+	pub fn get_entry(&self, id: ProjectEntryId) -> Option<&Entry> {
+		// TODO: Make this efficient
+		self.entries.iter().find(|entry| entry.id == id)
+	}
+
 	pub fn for_git_status() -> Self {
 		println!("Workspace::for_git_status()");
 		let git_status = git::get_status().expect("Failed to get git status");


### PR DESCRIPTION
Switch to running actual diffs on the file content (via `similar` crate).  This also adds basic support for 'show', 'diff', and 'status' modes as the various ways to initiate the diff.